### PR TITLE
Add direct GitHub Pages deployment option

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -50,20 +50,6 @@ jobs:
       - name: Integration test 4
         uses: ./
 
-  test-pages-deployment:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Test Pages deployment
-        uses: ./
-        with:
-          deploy: pages
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -50,6 +50,16 @@ jobs:
       - name: Integration test 4
         uses: ./
 
+  test-pages-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Test Pages deployment
+        uses: ./
+        with:
+          deploy: pages
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -52,6 +52,10 @@ jobs:
 
   test-pages-deployment:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v3
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: "false"
 
   deploy:
-    description: 'Specify what to do with the compiled site. Options are: [artifact]'
+    description: 'Specify what to do with the compiled site. Options are: [artifact, pages]'
     required: true
     default: "artifact"
 

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
 
   deploy:
     # Pages option requires GitHub the "Build and deployment" source to be set to "GitHub Actions"
+    # You must also ensure that GITHUB_TOKEN has permission "id-token: write".
     description: 'Specify what to do with the compiled site. Options are: [artifact, pages]'
     required: true
     default: "artifact"

--- a/action.yml
+++ b/action.yml
@@ -97,6 +97,21 @@ runs:
         name: build
         path: _site # TODO: Get this from the config file in case it's customized
 
+    - name: Setup Pages
+      if: inputs.deploy == 'pages'
+      uses: actions/configure-pages@v3
+
+    - name: Upload artifact
+      if: inputs.deploy == 'pages'
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: _site # TODO: Get this from the config file in case it's customized
+
+    - name: Deploy to GitHub Pages
+      id: pages-deployment
+      if: inputs.deploy == 'pages'
+      uses: actions/deploy-pages@v1
+
     # Now that the site is built, there are a few options for deployment.
     # We could push directly to the gh-pages branch, commit files to /docs,
     # or even use the GitHub Pages action to deploy the compiled site.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,7 @@ inputs:
     default: "false"
 
   deploy:
+    # Pages option requires GitHub the "Build and deployment" source to be set to "GitHub Actions"
     description: 'Specify what to do with the compiled site. Options are: [artifact, pages]'
     required: true
     default: "artifact"

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - name: Validate input
       id: validate-input
       run: |
-        if [[ "${{ inputs.deploy }}" != "artifact" ]]; then
+        if [[ "${{ inputs.deploy }}" != "artifact" ]] && [[ "${{ inputs.deploy }}" != "pages" ]]; then
           echo "Invalid input for deploy: ${{ inputs.deploy }}"
           exit 1
         fi


### PR DESCRIPTION
### Example usage:


```yaml
jobs:
  test-pages-deployment:
    runs-on: ubuntu-latest
    permissions:
      contents: read
      pages: write
      id-token: write
    steps:
      - uses: actions/checkout@v3

      - name: Test Pages deployment
        uses: ./
        with:
          deploy: pages

```

### Based on the GitHub static site workflow template

```yaml
# Simple workflow for deploying static content to GitHub Pages
name: Deploy static content to Pages

on:
  # Runs on pushes targeting the default branch
  push:
    branches: ["master"]

  # Allows you to run this workflow manually from the Actions tab
  workflow_dispatch:

# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
permissions:
  contents: read
  pages: write
  id-token: write

# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
concurrency:
  group: "pages"
  cancel-in-progress: false

jobs:
  # Single deploy job since we're just deploying
  deploy:
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v3
      - name: Setup Pages
        uses: actions/configure-pages@v3
      - name: Upload artifact
        uses: actions/upload-pages-artifact@v1
        with:
          # Upload entire repository
          path: '.'
      - name: Deploy to GitHub Pages
        id: deployment
        uses: actions/deploy-pages@v1

```
