### PR TITLE
Install Composer with development dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
       shell: bash
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-autoloader --no-dev && composer dump-autoload --quiet
+      run: composer install --prefer-dist --no-progress --no-autoloader && composer dump-autoload --quiet
       shell: bash
 
     - name: Build the site


### PR DESCRIPTION
This reverts commit c35ac69d1dc4675484e4cb680a955186a30bc495 "Install Composer without development dependencies"