### PR TITLE
Breaking: Rename `deploy` option to `deploy-to`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hydephp/action@master
         with:
-          deploy: pages
+          deploy-to: pages
           env-torchlight-token: ${{ secrets.TORCHLIGHT_TOKEN }}
           env-site-name: "'HydePHP Action'"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run workflow test 3
         uses: ./
         with:
-          deploy: artifact
+          deploy-to: artifact
 
   run-workflow-test-4:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ There are a few more configuration options available, that can be supplied to th
 
 | Input Name             | Description                                                                                                                                                     | Default Value |
 |------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `deploy`               | Specify what to do with the compiled site.<br><small>Supported options are: ["artifact", "pages"]</small>                                                       | "artifact"    |
-| `upload-artifact`      | Upload the site artifact, regardless of the `deploy` option                                                                                                     | `false`       |
+| `deploy-to`               | Specify what to do with the compiled site.<br><small>Supported options are: ["artifact", "pages"]</small>                                                       | "artifact"    |
+| `upload-artifact`      | Upload the site artifact, regardless of the `deploy-to` option                                                                                                     | `false`       |
 | `debug`                | Enable additional debug output                                                                                                                                  | `false`       |
 | `framework-version`    | Specify the HydePHP Framework version to use<br><small>(only applicable for [anonymous projects](https://hydephp.github.io/action/#anonymous-projects))</small> | "latest"      |
 | `env-site-name`        | Set the `SITE_NAME` environment variable                                                                                                                        | _none_        |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: hydephp/action@master
         with:
-          deploy: "pages"
+          deploy-to: "pages"
 ```
 
 Note that the GitHub token must have the proper permissions. You also need to configure your repository to use GitHub Pages using the Actions workflow.

--- a/action.yml
+++ b/action.yml
@@ -68,7 +68,7 @@ runs:
       if: inputs.debug == 'true'
       run: |
         echo "Debug mode: ${{ inputs.debug }}"
-        echo "Deploy option: ${{ inputs.deploy-to }}"
+        echo "Deployment option: ${{ inputs.deploy-to }}"
         echo "Install strategy: ${{ steps.determine-install-strategy.outputs.install-strategy }}"
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: "false"
 
-  deploy:
+  deploy-to:
     # Pages option requires GitHub the "Build and deployment" source to be set to "GitHub Actions"
     # You must also ensure that GITHUB_TOKEN has permission "id-token: write".
     description: 'Specify what to do with the compiled site. Options are: [artifact, pages]'
@@ -48,8 +48,8 @@ runs:
     - name: Validate input
       id: validate-input
       run: |
-        if [[ "${{ inputs.deploy }}" != "artifact" ]] && [[ "${{ inputs.deploy }}" != "pages" ]]; then
-          echo "Invalid input for deploy: ${{ inputs.deploy }}"
+        if [[ "${{ inputs.deploy-to }}" != "artifact" ]] && [[ "${{ inputs.deploy-to }}" != "pages" ]]; then
+          echo "Invalid input for deploy-to: ${{ inputs.deploy-to }}"
           exit 1
         fi
       shell: bash
@@ -68,7 +68,7 @@ runs:
       if: inputs.debug == 'true'
       run: |
         echo "Debug mode: ${{ inputs.debug }}"
-        echo "Deploy option: ${{ inputs.deploy }}"
+        echo "Deploy option: ${{ inputs.deploy-to }}"
         echo "Install strategy: ${{ steps.determine-install-strategy.outputs.install-strategy }}"
       shell: bash
 
@@ -135,25 +135,25 @@ runs:
       shell: bash
 
     - name: Upload artifact
-      if: inputs.deploy == 'artifact' || inputs.upload-artifact == 'true'
+      if: inputs.deploy-to == 'artifact' || inputs.upload-artifact == 'true'
       uses: actions/upload-artifact@v3
       with:
         name: build
         path: _site # TODO: Get this from the config file in case it's customized
 
     - name: Setup Pages
-      if: inputs.deploy == 'pages'
+      if: inputs.deploy-to == 'pages'
       uses: actions/configure-pages@v3
 
     - name: Upload artifact
-      if: inputs.deploy == 'pages'
+      if: inputs.deploy-to == 'pages'
       uses: actions/upload-pages-artifact@v1
       with:
         path: _site # TODO: Get this from the config file in case it's customized
 
     - name: Deploy to GitHub Pages
       id: pages-deployment
-      if: inputs.deploy == 'pages'
+      if: inputs.deploy-to == 'pages'
       uses: actions/deploy-pages@v1
 
     # Now that the site is built, there are a few options for deployment.

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ You can also enable artifact uploading in addition to another deployment method 
 
 >warning This method depends on [`actions/deploy-pages`](https://github.com/actions/deploy-pages), which is currently in public beta.
 
-You can also deploy the compiled site directly to GitHub Pages, by setting the `deploy` input to "pages".
+You can also deploy the compiled site directly to GitHub Pages, by setting the `deploy-to` input to "pages".
 
 ```yaml
 - uses: hydephp/action@master
@@ -155,7 +155,7 @@ Enables debug mode.
 *   **Required**: `false`
 *   **Default**: `"false"`
 
-### `deploy`
+### `deploy-to`
 
 Specifies what to do with the compiled site. Options are: `artifact` or `pages`.
 
@@ -165,7 +165,7 @@ Specifies what to do with the compiled site. Options are: `artifact` or `pages`.
 
 ### `upload-artifact`
 
-Uploads the compiled site as an artifact. (In addition to the deployment method specified by `deploy`. Makes no change if `deploy` is already set to `artifact`.)
+Uploads the compiled site as an artifact. (In addition to the deployment method specified by `deploy-to`. Makes no change if `deploy-to` is already set to `artifact`.)
 
 *   **Description**: Upload the compiled site as an artifact.
 *   **Required**: `false`

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ the compiled files manually.
 ```yaml
 - uses: hydephp/action@master
   with:
-    deploy: artifact # This is already the default, but it's here for clarity.
+    deploy-to: artifact # This is already the default, but it's here for clarity.
 ```
 
 You can also enable artifact uploading in addition to another deployment method with the `upload-artifact` input:
@@ -59,7 +59,7 @@ You can also enable artifact uploading in addition to another deployment method 
 ```yaml
 - uses: hydephp/action@master
   with:
-    deploy: pages
+    deploy-to: pages
     upload-artifact: true
 ```
 
@@ -72,7 +72,7 @@ You can also deploy the compiled site directly to GitHub Pages, by setting the `
 ```yaml
 - uses: hydephp/action@master
   with:
-    deploy: "pages"
+    deploy-to: "pages"
 ```
 
 You also need to make sure that your GitHub Pages source is set to "GitHub Actions" and that the `GITHUB_TOKEN` has the `id-token: write` and `pages: write` permissions.

--- a/tests/github-action-test-project-2/.github/workflows/test.yml
+++ b/tests/github-action-test-project-2/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           debug: true
           upload-artifact: true
-          deploy: "pages"
+          deploy-to: "pages"
 
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
### Abstract

This makes it much clearer what it does. I originally realized this may be named badly as Copilot always tries to autocomplete it as a boolean, like `deploy: false`.

Other options considered were:
- deployment-destination
- deploymentMethod 
- deploymentType

I chose `deploy-to` for three primary reasons:
1. It's very short
2. It's similar to the existing option
3. It was the first option GPT recommended

### Upgrade path

This change is breaking and has a rather high likelihood of impact. 

Existing workflows must change their workflows accordingly:

```yaml
- deploy: pages
+ deploy-to: pages
```

### Code review

I also asked ChatGPT about this with the following prompt:

```
I have a GitHub Action that builds and deploys static sites. I need suggestions for what to name the input option that controls where the site gets deployed to. Here is the description of the input:

    Specify what to do with the compiled site. Supported options are: ["artifact", "pages"]
```

**Which resulted in:**

How about naming the input option "deployment_target" or simply "target"? This option could accept a string value indicating where the compiled site should be deployed, such as "artifact" or "pages".

**As well as the following list after being asked to provide more options:**

1. **deploy-to**: This option name is self-explanatory and easy to understand. It could accept a string value of "artifact" or "pages".
4. **site-deployment**: This option name clearly indicates that it controls the deployment of the site. It could accept a string value of "artifact" or "pages".
5. **output-location**: This option name indicates where the output will be stored, which can be either an "artifact" or "pages" location.
6. **deploy-location**: This option name indicates where the compiled site will be deployed. It could accept a string value of "artifact" or "pages".