### PR TITLE
Add a config input parameter to append to `hyde.yml` configuration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -122,6 +122,11 @@ runs:
       run: echo "TORCHLIGHT_TOKEN=${{ inputs.env-torchlight-token }}" >> .env
       shell: bash
 
+    - name: Set up configuration
+      if: inputs.config != ''
+      run: echo "${{ inputs.config }}" >> hyde.yml
+      shell: bash
+
     - name: Build the site
       run: php hyde build --no-interaction --ansi
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,11 @@ inputs:
     required: false
     default: "."
 
+  config:
+    description: 'List of lines to add to the `hyde.yml` config file'
+    required: false
+    default: ""
+
   env-site-name:
     description: 'Set the `SITE_NAME` environment variable'
     required: false

--- a/docs/index.md
+++ b/docs/index.md
@@ -189,6 +189,27 @@ Specifies the directory containing the source files to build. This is useful if 
 *  **Required**: `false`
 *  **Default**: `"."`
 
+### `config`
+
+You can also specify configuration options using the `config` input. The lines in this input will be appended to the `hyde.yml` file in the root directory, allowing you to configure many parts of the Hyde project before the build.
+
+*   **Description**: List of lines to add to the `hyde.yml` config file
+*   **Required**: `false`
+*   **Default**: `""`
+
+Example:
+
+```yaml
+- uses: hydephp/action@config-array
+  with:
+    config: |
+      # Enter key-value Yaml here:
+      name: Example
+      url: ${{ github.deployment.url }}
+```
+
+See the [HydePHP documentation](https://hydephp.com/docs/1.x/customization#yaml-configuration) for more information on the available configuration options and how to use the `hyde.yml` file.
+
 ### Environment variables
 
 >warning If your inputs contain sensitive information, you should use [GitHub Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) to store them.


### PR DESCRIPTION
You can also specify configuration options using the `config` input. The lines in this input will be appended to the `hyde.yml` file in the root directory, allowing you to configure many parts of the Hyde project before the build. Fixes https://github.com/hydephp/action/issues/24

```yaml
- name: Build and Deploy HydePHP Site
  uses: hydephp/action@master
    with:
      deploy-to: "pages"
      config: |
        name: Example
        url: ${{ github.deployment.url }}
```