### PR TITLE
Deprecate old environment variable inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ There are a few more configuration options available, that can be supplied to th
 | `framework-version`    | Specify the HydePHP Framework version to use<br><small>(only applicable for [anonymous projects](https://hydephp.github.io/action/#anonymous-projects))</small> | "latest"      |
 | `directory`            | The directory to use as the project root                                                                                                                        | none          |
 | `config`               | String of lines to add to the `hyde.yml` config file                                                                                                            | none          |
-| `env-site-name`        | Set the `SITE_NAME` environment variable                                                                                                                        | _none_        |
-| `env-site-url`         | Set the `SITE_URL` environment variable                                                                                                                         | _none_        |
-| `env-torchlight-token` | Set the `TORCHLIGHT_TOKEN` environment variable                                                                                                                 | _none_        |
+| `env`                  | List of environment variables to set in the format `NAME=value`                                                                                                 | _none_        |
 
 ## Further documentation
 

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,7 @@ inputs:
     required: false
     default: ""
 
+  # The following three inputs are deprecated and will be removed in v2.0. They are kept in v1.x for backward compatibility, but users are encouraged to migrate to the new `env` input.
   env-site-name:
     description: '[Deprecated] Set the `SITE_NAME` environment variable. Use the `env` input instead with `SITE_NAME=value`'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -120,17 +120,17 @@ runs:
     # Inject environment variables
     - if: inputs.env-site-name != ''
       run: |
-        bash print-deprecation-warning.sh "env-site-name" "env: SITE_NAME=value"
+        bash print-deprecation-warning.sh "env-site-name" "env: SITE_NAME=value" "$GITHUB_WORKFLOW"
         echo "SITE_NAME=${{ inputs.env-site-name }}" >> .env
       shell: bash
     - if: inputs.env-site-url != ''
       run: |
-        bash print-deprecation-warning.sh "env-site-url" "env: SITE_URL=value"
+        bash print-deprecation-warning.sh "env-site-url" "env: SITE_URL=value" "$GITHUB_WORKFLOW"
         echo "SITE_URL=${{ inputs.env-site-url }}" >> .env
       shell: bash
     - if: inputs.env-torchlight-token != ''
       run: |
-        bash print-deprecation-warning.sh "env-torchlight-token" "env: TORCHLIGHT_TOKEN=value"
+        bash print-deprecation-warning.sh "env-torchlight-token" "env: TORCHLIGHT_TOKEN=value" "$GITHUB_WORKFLOW"
         echo "TORCHLIGHT_TOKEN=${{ inputs.env-torchlight-token }}" >> .env
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -119,13 +119,19 @@ runs:
 
     # Inject environment variables
     - if: inputs.env-site-name != ''
-      run: echo "SITE_NAME=${{ inputs.env-site-name }}" >> .env
+      run: |
+        bash print-deprecation-warning.sh "env-site-name" "env: SITE_NAME=value"
+        echo "SITE_NAME=${{ inputs.env-site-name }}" >> .env
       shell: bash
     - if: inputs.env-site-url != ''
-      run: echo "SITE_URL=${{ inputs.env-site-url }}" >> .env
+      run: |
+        bash print-deprecation-warning.sh "env-site-url" "env: SITE_URL=value"
+        echo "SITE_URL=${{ inputs.env-site-url }}" >> .env
       shell: bash
     - if: inputs.env-torchlight-token != ''
-      run: echo "TORCHLIGHT_TOKEN=${{ inputs.env-torchlight-token }}" >> .env
+      run: |
+        bash print-deprecation-warning.sh "env-torchlight-token" "env: TORCHLIGHT_TOKEN=value"
+        echo "TORCHLIGHT_TOKEN=${{ inputs.env-torchlight-token }}" >> .env
       shell: bash
 
     - name: Set custom environment variables

--- a/action.yml
+++ b/action.yml
@@ -38,13 +38,13 @@ inputs:
     default: ""
 
   env-site-name:
-    description: 'Set the `SITE_NAME` environment variable'
+    description: '[Deprecated] Set the `SITE_NAME` environment variable. Use the `env` input instead with `SITE_NAME=value`'
     required: false
   env-site-url:
-    description: 'Set the `SITE_URL` environment variable'
+    description: '[Deprecated] Set the `SITE_URL` environment variable. Use the `env` input instead with `SITE_URL=value`'
     required: false
   env-torchlight-token:
-    description: 'Set the `TORCHLIGHT_TOKEN` environment variable'
+    description: '[Deprecated] Set the `TORCHLIGHT_TOKEN` environment variable. Use the `env` input instead with `TORCHLIGHT_TOKEN=value`'
     required: false
 
   env:

--- a/docs/index.md
+++ b/docs/index.md
@@ -246,8 +246,9 @@ You can set arbitrary environment variables using the `env` input. Simply provid
   with:
     deploy-to: "pages"
     env: |
-      CUSTOM_VAR=value
-      DEPLOY_SHA=${{ github.sha }}
+      SITE_NAME=My Site
+      SITE_URL=https://example.com
+      TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}
 ```
 
 The environment variables will be available during the build process. Note that if you're using sensitive information, you should use GitHub Secrets instead of hardcoding the values. Also make sure your input is valid "dotenv" syntax.

--- a/docs/index.md
+++ b/docs/index.md
@@ -217,6 +217,24 @@ See the [HydePHP documentation](https://hydephp.com/docs/1.x/customization#yaml-
 
 >warning If your inputs contain sensitive information, you should use [GitHub Secrets](https://docs.github.com/en/actions/reference/encrypted-secrets) to store them.
 
+#### `env`
+
+You can set arbitrary environment variables using the `env` input. Simply provide each variable in KEY=VALUE format, one per line:
+
+```yaml
+- uses: hydephp/action@master
+  with:
+    deploy-to: "pages"
+    env: |
+      SITE_NAME=My Site
+      SITE_URL=https://example.com
+      TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}
+```
+
+The environment variables will be available during the build process. Note that if you're using sensitive information, you should use GitHub Secrets instead of hardcoding the values. Also make sure your input is valid "dotenv" syntax.
+
+### Deprecated inputs
+
 You can also pass set the following inputs to be passed as environment variables for the build process:
 
 #### `env-site-name`
@@ -236,19 +254,3 @@ Sets the `SITE_URL` environment variable
 > Deprecated: Use the `env` input instead with `TORCHLIGHT_TOKEN=value`
 
 Sets the `TORCHLIGHT_TOKEN` environment variable
-
-#### `env`
-
-You can set arbitrary environment variables using the `env` input. Simply provide each variable in KEY=VALUE format, one per line:
-
-```yaml
-- uses: hydephp/action@master
-  with:
-    deploy-to: "pages"
-    env: |
-      SITE_NAME=My Site
-      SITE_URL=https://example.com
-      TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}
-```
-
-The environment variables will be available during the build process. Note that if you're using sensitive information, you should use GitHub Secrets instead of hardcoding the values. Also make sure your input is valid "dotenv" syntax.

--- a/docs/index.md
+++ b/docs/index.md
@@ -220,12 +220,21 @@ See the [HydePHP documentation](https://hydephp.com/docs/1.x/customization#yaml-
 You can also pass set the following inputs to be passed as environment variables for the build process:
 
 #### `env-site-name`
+> [!WARNING]  
+> Deprecated: Use the `env` input instead with `SITE_NAME=value`
+
 Sets the `SITE_NAME` environment variable
 
 #### `env-site-url`
+> [!WARNING]  
+> Deprecated: Use the `env` input instead with `SITE_URL=value`
+
 Sets the `SITE_URL` environment variable
 
 #### `env-torchlight-token`
+> [!WARNING]  
+> Deprecated: Use the `env` input instead with `TORCHLIGHT_TOKEN=value`
+
 Sets the `TORCHLIGHT_TOKEN` environment variable
 
 #### `env`

--- a/print-deprecation-warning.sh
+++ b/print-deprecation-warning.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-# Usage: print-deprecation-warning.sh "old_input" "new_input"
-# Example: print-deprecation-warning.sh "env-site-name" "env: SITE_NAME=value"
+# Usage: print-deprecation-warning.sh "old_input" "new_input" "workflow_file"
+# Example: print-deprecation-warning.sh "env-site-name" "env: SITE_NAME=value" ".github/workflows/build.yml"
 
 old_input=$1
 new_input=$2
+workflow_file=$3
 
-echo "::warning file=.github/workflows/build.yml,title=Deprecation Notice::The '$old_input' input is deprecated and will be removed in \`hydephp/action\` v2.0. Please use '$new_input' instead. See https://github.com/hydephp/action/pull/46 for more information."
+echo "::warning file=$workflow_file,title=Deprecation Notice::The '$old_input' input is deprecated and will be removed in \`hydephp/action\` v2.0. Please use '$new_input' instead. See https://github.com/hydephp/action/pull/46"

--- a/print-deprecation-warning.sh
+++ b/print-deprecation-warning.sh
@@ -7,4 +7,4 @@ old_input=$1
 new_input=$2
 workflow_file=$3
 
-echo "::warning file=$workflow_file,title=Deprecation Notice::The '$old_input' input is deprecated and will be removed in \`hydephp/action\` v2.0. Please use '$new_input' instead. See https://github.com/hydephp/action/pull/46"
+echo "::warning file=$workflow_file,title=Deprecation Notice::The '$old_input' input is deprecated and will be removed in \`hydephp/action\` v2.0. Please use '$new_input' instead. See https://github.com/hydephp/action/pull/46 for more information."

--- a/print-deprecation-warning.sh
+++ b/print-deprecation-warning.sh
@@ -6,4 +6,4 @@
 old_input=$1
 new_input=$2
 
-echo "::warning::The '$old_input' input is deprecated and will be removed in `hydephp/action` v2.0. Please use '$new_input' instead. See https://github.com/hydephp/action/pull/46"
+echo "::warning file=.github/workflows/build.yml,title=Deprecation Notice::The '$old_input' input is deprecated and will be removed in \`hydephp/action\` v2.0. Please use '$new_input' instead. See https://github.com/hydephp/action/pull/46 for more information."

--- a/print-deprecation-warning.sh
+++ b/print-deprecation-warning.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Usage: print-deprecation-warning.sh "old_input" "new_input"
+# Example: print-deprecation-warning.sh "env-site-name" "env: SITE_NAME=value"
+
+old_input=$1
+new_input=$2
+
+echo "::warning::The '$old_input' input is deprecated and will be removed in v2.0. Please use '$new_input' instead."

--- a/print-deprecation-warning.sh
+++ b/print-deprecation-warning.sh
@@ -6,4 +6,4 @@
 old_input=$1
 new_input=$2
 
-echo "::warning::The '$old_input' input is deprecated and will be removed in v2.0. Please use '$new_input' instead."
+echo "::warning::The '$old_input' input is deprecated and will be removed in `hydephp/action` v2.0. Please use '$new_input' instead. See https://github.com/hydephp/action/pull/46"

--- a/tests/unit/test-deprecation-warnings.sh
+++ b/tests/unit/test-deprecation-warnings.sh
@@ -4,8 +4,8 @@ test_deprecation_warnings() {
   base_dir="$(pwd)"
   
   # Test case 1: Basic deprecation warning
-  output=$(bash "$base_dir/print-deprecation-warning.sh" "old-input" "new-input")
-  expected="::warning::The 'old-input' input is deprecated and will be removed in v2.0. Please use 'new-input' instead."
+  output=$(bash "$base_dir/print-deprecation-warning.sh" "old-input" "new-input" ".github/workflows/build.yml")
+  expected="::warning file=.github/workflows/build.yml,title=Deprecation Notice::The 'old-input' input is deprecated and will be removed in \`hydephp/action\` v2.0. Please use 'new-input' instead. See https://github.com/hydephp/action/pull/46 for more information."
   
   if [[ "$output" != "$expected" ]]; then
     echo "Test 1 failed: Deprecation warning not formatted correctly"

--- a/tests/unit/test-deprecation-warnings.sh
+++ b/tests/unit/test-deprecation-warnings.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+test_deprecation_warnings() {
+  base_dir="$(pwd)"
+  
+  # Test case 1: Basic deprecation warning
+  output=$(bash "$base_dir/print-deprecation-warning.sh" "old-input" "new-input")
+  expected="::warning::The 'old-input' input is deprecated and will be removed in v2.0. Please use 'new-input' instead."
+  
+  if [[ "$output" != "$expected" ]]; then
+    echo "Test 1 failed: Deprecation warning not formatted correctly"
+    echo "Expected: $expected"
+    echo "Got: $output"
+    exit 1
+  fi
+}
+
+# Run the tests
+test_deprecation_warnings


### PR DESCRIPTION
### Abstract

With the improvements made in https://github.com/hydephp/action/pull/45 we no longer need the following inputs, and thus these are deprecated:



| Input Name             | Description                                                                                                                                                     | Default Value |
|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
| `env-site-name`        | Set the `SITE_NAME` environment variable                                                                                                                        | _none_        |
| `env-site-url`         | Set the `SITE_URL` environment variable                                                                                                                         | _none_        |
| `env-torchlight-token` | Set the `TORCHLIGHT_TOKEN` environment variable                                                                                                                 | _none_        |

### Removal Timeline

They will be removed in v2.0.

### Upgrade Guide

It's very easy to upgrade, just replace the legacy versions with the following:

```yaml
- name: Old syntax
  uses: hydephp/action@master
  with:
    # Replace this:
    env-site-name: "'HydePHP Action'"
    env-torchlight-token: ${{ secrets.TORCHLIGHT_TOKEN }}

- name: New syntax
  uses: hydephp/action@master
  with:
    # With this:
    env: |
      SITE_NAME='HydePHP Action'
      TORCHLIGHT_TOKEN=${{ secrets.TORCHLIGHT_TOKEN }}
```

Of course, you only need to specify the values you actually use.