### PR TITLE
[2.x] Support custom artifact names

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -44,6 +44,7 @@ jobs:
         uses: ./
         with:
           debug: true
+          artifact-name: "workflow-test-2-build"
 
 
   run-workflow-test-3:
@@ -70,6 +71,9 @@ jobs:
 
       - name: Run workflow test 4
         uses: ./
+        with:
+          artifact-name: "workflow-test-4-build"
+
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           debug: true
 
+
   run-workflow-test-3:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +55,8 @@ jobs:
         uses: ./
         with:
           deploy-to: artifact
+          artifact-name: "workflow-test-3-build"
+
 
   run-workflow-test-4:
     runs-on: ubuntu-latest

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,11 @@ inputs:
     required: false
     default: ''
 
+  artifact-name:
+    description: 'Name of the artifact to upload (defaults to "build")'
+    required: false
+    default: "build"
+
 outputs:
   install-strategy:
     description: 'The install strategy used'
@@ -160,7 +165,7 @@ runs:
       if: inputs.deploy-to == 'artifact' || inputs.upload-artifact == 'true'
       uses: actions/upload-artifact@v4
       with:
-        name: build
+        name: ${{ inputs.artifact-name }}
         path: _site # TODO: Get this from the config file in case it's customized
 
     - name: Setup Pages

--- a/tests/github-action-test-project-1/.github/workflows/test.yml
+++ b/tests/github-action-test-project-1/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           debug: true
           upload-artifact: true
+          artifact-name: "test-project-1-build"
 
       - uses: actions/download-artifact@v3
         with:

--- a/tests/github-action-test-project-2/.github/workflows/test.yml
+++ b/tests/github-action-test-project-2/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           debug: true
           upload-artifact: true
           deploy-to: "pages"
+          artifact-name: "test-project-2-build"
 
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
              **Breaking Changes** documented in https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

> **Uploading to the same named Artifact multiple times.**
> 
> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

This causes an issue in our tests where we run the action multiple times. This probably won't be an issue for real usages unless users want to deploy multiple sites from the same job, which I guess could happen? Best way to resolve it might then be to so support an input for custom artifact names.

_Originally posted by @caendesilva in https://github.com/hydephp/action/issues/35#issuecomment-2160289803_
            