### PR TITLE
feat: add RSS as input to build rss during action run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,16 @@ You can enable Pages by visiting the Pages section of your repository settings, 
 
 There are a few more configuration options available, that can be supplied to the action using the `with` keyword, as shown in the examples above.
 
-| Input Name             | Description                                                                                                                                                     | Default Value |
-|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| `deploy-to`            | Specify what to do with the compiled site.<br><small>Supported options are: ["artifact", "pages"]</small>                                                       | "artifact"    |
-| `upload-artifact`      | Upload the site artifact, regardless of the `deploy-to` option                                                                                                  | `false`       |
-| `debug`                | Enable additional debug output                                                                                                                                  | `false`       |
-| `framework-version`    | Specify the HydePHP Framework version to use<br><small>(only applicable for [anonymous projects](https://hydephp.github.io/action/#anonymous-projects))</small> | "latest"      |
-| `directory`            | The directory to use as the project root                                                                                                                        | none          |
-| `config`               | String of lines to add to the `hyde.yml` config file                                                                                                            | none          |
-| `env`                  | List of environment variables to set in the format `NAME=value`                                                                                                 | _none_        |
+| Input Name          | Description                                                                                                                                                     | Default Value |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
+| `deploy-to`         | Specify what to do with the compiled site.<br><small>Supported options are: ["artifact", "pages"]</small>                                                       | "artifact"    |
+| `upload-artifact`   | Upload the site artifact, regardless of the `deploy-to` option                                                                                                  | `false`       |
+| `debug`             | Enable additional debug output                                                                                                                                  | `false`       |
+| `framework-version` | Specify the HydePHP Framework version to use<br><small>(only applicable for [anonymous projects](https://hydephp.github.io/action/#anonymous-projects))</small> | "latest"      |
+| `directory`         | The directory to use as the project root                                                                                                                        | none          |
+| `config`            | String of lines to add to the `hyde.yml` config file                                                                                                            | none          |
+| `env`               | List of environment variables to set in the format `NAME=value`                                                                                                 | _none_        |
+| `rss`               | Enable the build of the RSS feed                                                                                                                                | `false`       |
 
 ## Further documentation
 

--- a/action.yml
+++ b/action.yml
@@ -159,6 +159,11 @@ runs:
       run: php hyde build --no-interaction --ansi
       shell: bash
 
+    - name: Build the RSS feed
+      if: inputs.rss == 'true'
+      run: php hyde build:rss --no-interaction --ansi
+      shell: bash
+
     # TODO: Add post-build hook to run some bash commands?
 
     - name: Upload artifact

--- a/docs/index.md
+++ b/docs/index.md
@@ -233,6 +233,15 @@ You can set arbitrary environment variables using the `env` input. Simply provid
 
 The environment variables will be available during the build process. Note that if you're using sensitive information, you should use GitHub Secrets instead of hardcoding the values. Also make sure your input is valid "dotenv" syntax.
 
+### `rss`
+
+Enables build of the RSS feed.
+
+*   **Description**: Enable build of RSS.
+*   **Required**: `false`
+*   **Default**: `"false"`
+
+
 ### Deprecated inputs
 
 You can also pass set the following inputs to be passed as environment variables for the build process:


### PR DESCRIPTION
This PR is a first step in fixing #50 and includes the functionality but is lacking tests to confirm the changes work. 
I still need to see how this could be tested, any pointers are very welcome. Will see if I can follow up later today.

If you believe the solution approach needs to be in a different direction you can always let me know.

Resolves #50 